### PR TITLE
Astractl 4558 identity ignore iat check

### DIFF
--- a/examples/martini-example/main.go
+++ b/examples/martini-example/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	jwtmiddleware "github.com/auth0/go-jwt-middleware"
+	jwtmiddleware "github.com/NetApp-Polaris/go-jwt-middleware"
 	"github.com/form3tech-oss/jwt-go"
 	"github.com/go-martini/martini"
 )

--- a/examples/negroni-example/main.go
+++ b/examples/negroni-example/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	jwtmiddleware "github.com/auth0/go-jwt-middleware"
+	jwtmiddleware "github.com/NetApp-Polaris/go-jwt-middleware"
 	"github.com/form3tech-oss/jwt-go"
 	"github.com/gorilla/mux"
 	"github.com/urfave/negroni"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/auth0/go-jwt-middleware
+module github.com/NetApp/go-jwt-middleware
 
 go 1.14
 

--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -207,7 +207,8 @@ func (m *JWTMiddleware) CheckJWT(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		e, ok := err.(*jwt.ValidationError)
 		// Return an error if the cast didn't work, or the error was not caused by the IAT validation
-		if !ok || ok && e.Errors & jwt.ValidationErrorIssuedAt == 0 {
+		nonIatErrsDetected := e.Errors &^ jwt.ValidationErrorIssuedAt != 0
+		if !ok || ok && nonIatErrsDetected {
 			m.logf("Error parsing token: %v", err)
 			m.Options.ErrorHandler(w, r, err.Error())
 			return fmt.Errorf("Error parsing token: %w", err)


### PR DESCRIPTION
### Description

> The IAT check in jwt-go is very strict, and with drift being not uncommon, this has been the cause of unnecessary failures (the IAT field is optional per RFC 7519). This change ignores the jwt.ValidationErrorIssuedAt error if it is returned by jwt.Parse() in JWTMiddleware.CheckJWT(). 

### Testing

> jwtmiddleware_test.go ran successfully. I will be adding unit testing for this change in a separate card, astractl-5206.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
