### PR TITLE
ASTRACTL4558: fix module name in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/NetApp/go-jwt-middleware
+module github.com/NetApp-Polaris/go-jwt-middleware
 
 go 1.14
 


### PR DESCRIPTION
### Description

> Fix typo in module name in go.mod.