### PR TITLE
Astractl 5206 unit test and fix iat err handling

### DIFF
--- a/jwtmiddleware.go
+++ b/jwtmiddleware.go
@@ -213,6 +213,7 @@ func (m *JWTMiddleware) CheckJWT(w http.ResponseWriter, r *http.Request) error {
 			m.Options.ErrorHandler(w, r, err.Error())
 			return fmt.Errorf("Error parsing token: %w", err)
 		}
+		parsedToken.Valid = true
 	}
 
 	if m.Options.SigningMethod != nil && m.Options.SigningMethod.Alg() != parsedToken.Header["alg"] {


### PR DESCRIPTION
Added a unit test to confirm that an IAT claim value that would cause a failure (401) in the  auth0/go-jwt-middleware, returns a 200 instead.

### Description
> New unit test sets the IAT claim to a value much larger than the current time, and expects the http status to return 200. Confirmed that this would have previously returned 401. Also fix a bug by resetting the parsedToken.Valid field to True. After this merges, I'll need to open a PR to change the release reference in the identity service.

### References
> ASTRACTL-4558

### Testing
> The unit tests in this package can be run on the command line without a virtual environment or container.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
